### PR TITLE
Correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/bep/golibsass/branch/master/graph/badge.svg)](https://codecov.io/gh/bep/golibsass)
 [![GoDoc](https://godoc.org/github.com/bep/golibsass/libsass?status.svg)](https://godoc.org/github.com/bep/golibsass/libsass)
 
-**Note:** LibSASS (the C++ library that this project wraps) is now deprecatd. You may want to try https://github.com/bep/godartsass
+**Note:** LibSASS (the C++ library that this project wraps) is now deprecated. You may want to try https://github.com/bep/godartsass
 
 The primary motivation for this project is to provide `SCSS` support to [Hugo](https://gohugo.io/). I welcome PRs with bug fixes. I will also consider adding functionality, but please raise an issue discussing it first.
 


### PR DESCRIPTION
Fix `deprecatd` to`deprecated`.