### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,8 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Install staticcheck
+      if: matrix.platform != 'windows-latest'
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
-      shell: bash
-    - name: Install golint
-      run: go install golang.org/x/lint/golint@latest
       shell: bash
     - name: Update PATH
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -34,6 +32,7 @@ jobs:
       run: "diff <(gofmt -d .) <(printf '')"
       shell: bash
     - name: Staticcheck
+      if: matrix.os != 'windows-latest'
       run: staticcheck ./...
     - name: Test
       run: go test -race ./libsass -coverprofile=coverage.txt -covermode=atomic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.19.x, 1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -18,6 +18,9 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+    - if: matrix.os == 'windows-latest'
+      run: |
+        Choco-Install -PackageName mingw -ArgumentList "--version","10.2.0","--allow-downgrade"
     - name: Install staticcheck
       if: matrix.platform != 'windows-latest'
       run: go install honnef.co/go/tools/cmd/staticcheck@latest
@@ -35,11 +38,4 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: staticcheck ./...
     - name: Test
-      run: go test -race ./libsass -coverprofile=coverage.txt -covermode=atomic
-    - name: Upload coverage
-      if: success() && matrix.os == 'ubuntu-latest'
-      run: |
-        curl -s https://codecov.io/bash | bash
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      shell: bash
+      run: go test -race ./libsass

--- a/internal/libsass/a__cgo.go
+++ b/internal/libsass/a__cgo.go
@@ -2,7 +2,6 @@
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-//
 package libsass
 
 // #cgo CFLAGS: -O2 -fPIC

--- a/internal/libsass/a__importer.go
+++ b/internal/libsass/a__importer.go
@@ -2,7 +2,6 @@
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-//
 package libsass
 
 // #include <stdint.h>
@@ -34,6 +33,7 @@ var importsStore = &idMap{
 
 // AddImportResolver adds a function to resolve imports in LibSASS.
 // Make sure to run call DeleteImportResolver when done.
+//
 //go:nocheckptr
 func AddImportResolver(opts SassOptions, resolver ImportResolver) int {
 	i := importsStore.Set(resolver)

--- a/internal/libsass/a__libsass.go
+++ b/internal/libsass/a__libsass.go
@@ -2,7 +2,6 @@
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-//
 package libsass
 
 // #include "stdlib.h"

--- a/internal/libsass/a__types.go
+++ b/internal/libsass/a__types.go
@@ -2,7 +2,6 @@
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
-//
 package libsass
 
 // #include "stdint.h"

--- a/libsass_src/src/json.cpp
+++ b/libsass_src/src/json.cpp
@@ -1286,7 +1286,10 @@ static void emit_number(SB *out, double num)
    * like 0.3 -> 0.299999999999999988898 .
    */
   char buf[64];
-  sprintf(buf, "%.16g", num);
+  // patched by @bep to get rid of warning on MacOS: 
+  //     "due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead".
+  //sprintf(buf, "%.16g", num);
+  snprintf(buf, sizeof(buf), "%.16g", num);
 
   if (number_is_valid(buf))
     sb_puts(out, buf);


### PR DESCRIPTION
To get rid of warnings on MacOS.

This should probably be patched upstream, but that project seem to be deprecated.

See https://github.com/gohugoio/hugo/issues/10629
