### PR TITLE
libsass_src: Path libsass to throw detailed e.g. "Too many open files" exception

### DIFF
--- a/libsass_src/src/file.cpp
+++ b/libsass_src/src/file.cpp
@@ -26,6 +26,7 @@
 #include "util.hpp"
 #include "util_string.hpp"
 #include "sass2scss.h"
+#include <errno.h>
 
 #ifdef _WIN32
 # include <windows.h>
@@ -478,7 +479,9 @@ namespace Sass {
         struct stat st;
         if (stat(path.c_str(), &st) == -1 || S_ISDIR(st.st_mode)) return 0;
         FILE* fd = std::fopen(path.c_str(), "rb");
-        if (fd == nullptr) return nullptr;
+        if (fd == nullptr) {
+           throw Exception::OperationError("error reading file \"" + path + "\": " + strerror(errno));
+        }
         const std::size_t size = st.st_size;
         char* contents = static_cast<char*>(malloc(st.st_size + 2 * sizeof(char)));
         if (std::fread(static_cast<void*>(contents), 1, size, fd) != size) {


### PR DESCRIPTION
In Hugo we have had mysterious and hard-to-debug error reports about faliling imports on MacOs for files that's obviously there.

Instead of just failing with a general error, we now throw a more detailed error message. From the Hugo side it looks like:

```
Error: error building site: TOCSS: failed to transform "hb/scss/index.scss" (text/x-scss): "<stream>:1:1": error reading file "/Users/bep/dump/large-site-test/_vendor/github.com/twbs/bootstrap/scss/_functions.scss": Too many open files
```

See https://github.com/gohugoio/hugo/issues/12649
